### PR TITLE
Fix adding empty days to history

### DIFF
--- a/src/lib/user-utils.js
+++ b/src/lib/user-utils.js
@@ -12,8 +12,8 @@ export function addToHistory() {
     user.update(user => {
 
       // possible empty days
-      const daysBetween = dayjs().diff(get(user).lastUpdated, 'day');
-      for (let i = daysBetween - 1; i < 0; i++) {
+      const daysBetween = dayjs().diff(user.lastUpdated, 'day');
+      for (let i = daysBetween - 1; i > 0; i--) {
         user.history.unshift({
           // number of ms in a day
           date: user.lastUpdated - (86400000 * i),

--- a/src/lib/user-utils.js
+++ b/src/lib/user-utils.js
@@ -10,6 +10,18 @@ import { loggedIn, profile, reducedMotion, shouldUpdate, user } from './stores';
 export function addToHistory() {
   if (dayjs().isAfter(get(user).lastUpdated, 'day')) {
     user.update(user => {
+
+      // possible empty days
+      const daysBetween = dayjs().diff(get(user).lastUpdated, 'day');
+      for (let i = daysBetween - 1; i < 0; i++) {
+        user.history.unshift({
+          // number of ms in a day
+          date: user.lastUpdated - (86400000 * i),
+          projects: [],
+          goal: user.goal,
+        });
+      }
+
       // Use unshift for reverse chronological order
       user.history.unshift({
         date: user.lastUpdated,


### PR DESCRIPTION
Fixes #28 

(I hope)

If there is more than one day since last updated, loop for the number of empty days and add them to the history.